### PR TITLE
add install instructions, improve example, add  check

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,20 @@
 Shmux is a tmux session management tool written purely in shell script.
 
 ### Installation
-TBD
+
+This puts shmux in a consistent location, so that your session files can source it
+```
+git clone https://github.com/typecraft-dev/shmux ~/.shmux
+echo "alias \"shmux\"=\"./.shmux\"" >> ~/.bashrc
+```
+
+### Usage
+
+In a project directory, create a .shmux file, and run `shmux`
+```
+cp example.sh ~/Projects/my_app/.shmux
+shmux
+```
+
+tada!
+

--- a/example.sh
+++ b/example.sh
@@ -1,12 +1,17 @@
-. ./launcher.sh
+. $HOME/.shmux/launcher.sh
 
 project_root ~/dotfiles
-session_name "final_dotfiles"
+session_name "my_shmux_session"
 
-new_session
-rename_window "code"
-run_command "nvim"
-new_window "servers"
-split_horizontal 50%
+if session_exists 2>/dev/null; then
+  attach_to_session
+else
+  new_session
+  rename_window "code"
+  run_command "nvim"
+  new_window "servers"
+  split_horizontal 50%
 
-attach_to_session
+  attach_to_session
+fi
+

--- a/launcher.sh
+++ b/launcher.sh
@@ -19,8 +19,13 @@ select_pane() {
 }
 
 new_session() {
-  dir=$(readlink --canonicalize "$ROOT")
+  dir=$(readlink -f "$ROOT")
   tmux new-session -d -s "$SESSION_NAME" -c "$ROOT"
+}
+
+# Check if the session exists
+session_exists() {
+  tmux has-session -t "$SESSION_NAME" 
 }
 
 new_window() {


### PR DESCRIPTION
- Add install instructions
- add usage instructions
- add `session_exists` function


This allows users to optionally check to see if a session exists, and not re-create it or add windows to it if they don't want to (see example)

This also instructs users to clone repo to `~/.shmux` and then an optional alias for initializing a `.shmux` file inside of a project directory:

e.g.  ~/Projects/my_app/.shmux
``` bash
. $HOME/.shmux/launcher.sh

project_root ./
session_name "my_app"

if session_exists 2>/dev/null; then
    attach_to_session
else
  new_session
  rename_window "code"
  new_window "servers"
  split_horizontal 50%

  attach_to_session
fi
```
Then a user can:
```
cd ~/Projects/my_app
shmux
```

and they're in!